### PR TITLE
Adding spectral extraction from vornoi map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.idea/

--- a/xmm_simulator.egg-info/SOURCES.txt
+++ b/xmm_simulator.egg-info/SOURCES.txt
@@ -20,7 +20,6 @@ xmm_simulator/fwc/PN_FWC.fits.gz
 xmm_simulator/imgs/MOS1_mask.fits.gz
 xmm_simulator/imgs/MOS2_mask.fits.gz
 xmm_simulator/imgs/PN_mask.fits.gz
-xmm_simulator/pts/templates_pts.dat
 xmm_simulator/pts/templates_pts_hard.dat
 xmm_simulator/rmfs/MOS1.rmf
 xmm_simulator/rmfs/MOS2.rmf


### PR DESCRIPTION
I added 'ExtractSpectrumVoronoi' in simulator.py. It uses 'gen_spec_evt_pix' in spectral.py. It takes a list of pixels in the XMM mock image as an input, selects events within those pixels, computes the arf by mapping the pixels to the original box_size (e.g. 512x512). Following Eqs. (2-6) in Lovisari+24, I verified that the 1d temperatures inferred from the 2d voronoi Tx map agrees with the standard spectral analysis in radial bins. 
![Tx_prof_from2dvoronoi_vs_radialbins](https://github.com/domeckert/xmm_simulator/assets/56032596/751fe62b-8eaf-4f6a-b161-9366a35c84ad)
