### PR TITLE
Addition of idealized event files as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ A directory containing the XMM calibration files (CCF) must also be available, s
 
 https://www.cosmos.esa.int/web/xmm-newton/current-calibration-files
 
+The xmm_simulator works with two set-ups, the first one is  with data cubes containing a model spectrum in unit of photons/cm2/s/keV for each image pixel.
+The second one is with a list of idealized events, generated for example with pyxsim.
+The set up is very similar, you just need to provide the box file or the event file in the proper keywords when defining the XMMSimulator class. An example is below.
+
+
 ## Initialization
 
 The xmm_simulator code is meant to work with data cubes containing a model spectrum in unit of photons/cm2/s/keV for each image pixel. The data cube must be of size N_ene x Npix_x x Npix_y , with N_ene the number of energy bins in the model spectrum, and Npix_x, Npix_y the number of input image pixels on the X and Y axes. The box size (in degrees) and the energy band definition must be provided by the user.
@@ -24,7 +29,18 @@ The xmm_simulator code is meant to work with data cubes containing a model spect
 To initiate the code, do the following:
 
     import xmm_simulator
+
+    #Working with data cubes
     xmmsim = xmm_simulator.XMMSimulator(boxfile='/path/to/data_cube',
+                                        ccfpath='/path/to/ccf/',
+                                        instrument='MOS1', # one constructor per instrument, can be 'MOS1', 'MOS2', or 'PN'
+                                        tsim=25000, # simulation exposure time
+                                        box_size=0.5, # size of provided image in degrees
+                                        box_ene=None # numpy array containing the energy definition, i.e. it must have a size of N_ene+1 to contain the lower and upper boundaries of energy channels
+                                        )
+
+    #Working with idealized events
+    xmmsim = xmm_simulator.XMMSimulator(eventfile_input='/path/to/event_file',
                                         ccfpath='/path/to/ccf/',
                                         instrument='MOS1', # one constructor per instrument, can be 'MOS1', 'MOS2', or 'PN'
                                         tsim=25000, # simulation exposure time

--- a/build/lib/xmm_simulator/simulator.py
+++ b/build/lib/xmm_simulator/simulator.py
@@ -6,7 +6,7 @@ from .background import gen_qpb_image, gen_skybkg_image, gen_skybkg_spectrum, ge
 from .utils import get_ccf_file_names, calc_arf, get_data_file_path
 from .imaging import gen_image_box, save_maps, exposure_map
 from .spectral import gen_spec_box, save_spectrum, gen_spec_evt, gen_spec_evt_pix
-from .event_file import gen_phot_box, gen_evt_list, gen_qpb_evt, merge_evt, save_evt_file, gen_image_evt, load_events
+from .event_file import gen_phot_box, gen_evt_list, gen_qpb_evt, merge_evt, save_evt_file, gen_image_evt, load_events, gen_phot_evtlist
 from .point_sources import gen_sources, pts_box
 from scipy.interpolate import interp1d
 
@@ -14,8 +14,8 @@ class XMMSimulator(object):
     """
 
     """
-    def __init__(self, boxfile, ccfpath, instrument, tsim,
-                 box_size=0.5, box_ene=None, abund='angr'):
+    def __init__(self, ccfpath, instrument, tsim, boxfile=None,
+                 evtfile_input=None, box_size=0.5, box_ene=None, abund='angr'):
         """
         Constructor of class XMMSimulator
 
@@ -27,6 +27,8 @@ class XMMSimulator(object):
         :type instrument: str
         :param tsim: Simulation exposure time
         :type tsim: float
+        :param evtfile_input: Input event file (in the format of output event file from pyxsim)
+        :type evtfile_input: str
         :param box_size: Size of the provided simulation box in degrees (defaults to 0.5)
         :type box_size: float
         :param box_ene: Numpy array containing the energy definition of the box. If None, defaults to a linear grid between 0.1 and 10 keV with a step of 0.02
@@ -43,20 +45,49 @@ class XMMSimulator(object):
             print('ERROR: instrument should be one of PN, MOS1, or MOS2')
             return
 
-        fb = fits.open(boxfile)
+        try:
+            if boxfile is None and evtfile_input is None:
+                raise ValueError
+        except ValueError:
+            print('ERROR: you need to provide at least a path to a boxfile or a path to an input eventfile')
 
-        self.box = fb[0].data
+        try:
+            if boxfile is not None and evtfile_input is not None:
+                raise ValueError
+        except ValueError:
+            print('ERROR: you provided a path to a boxfile and a path to an input eventfile. Choose one of the two')
 
-        self.box_size = box_size * 60. # arcmin
 
-        fb.close()
+        self.box_size = box_size * 60.  # arcmin
+        if boxfile:
+            fb = fits.open(boxfile)
+
+            self.box = fb[0].data
+
+            self.pixsize = self.box_size / self.box.shape[0]
+
+            self.boxshape0 = self.box.shape[0]
+            self.boxshape1 = self.box.shape[1]
+            self.boxshape2 = self.box.shape[2]
+
+            fb.close()
+            self.evtfile_input = None
+        else:
+            self.box = None
+            self.evtfile_input = evtfile_input
+            self.boxshape0 = 100#512
+            self.boxshape1 = 100#512
+            self.boxshape2 = 99#495
+            self.pixsize = self.box_size / self.boxshape0
+
 
         if box_ene is None:
-            self.box_ene = np.arange(0.1, 10.01, 0.02)
-
-            self.box_ene_mean = np.arange(0.11, 10., 0.02)
-
-            self.box_ene_width = 0.02
+            #self.box_ene = np.arange(0.1, 10.01, 0.02)
+            #self.box_ene_mean = np.arange(0.11, 10., 0.02)
+            #self.box_ene_width = 0.02
+            self.box_ene = np.linspace(0.1, 10.01, self.boxshape2+1)
+            self.box_ene_mean = np.linspace(0.11, 10., self.boxshape2)
+            self.box_ene_width = np.diff(self.box_ene_mean)[0]
         else:
             self.box_ene = box_ene
 
@@ -135,12 +166,14 @@ class XMMSimulator(object):
         Compute the ARFs for each point on the box
 
         """
+        #redefined by rseppi as self.pixsize
+        #pixsize = self.box_size / self.box.shape[0]  # by default box size is 30 arcmin
 
-        pixsize = self.box_size / self.box.shape[0]  # by default box size is 30 arcmin
+        #y, x = np.indices(self.box[:, :, 0].shape)
+        y, x = np.indices((self.boxshape0, self.boxshape1))
 
-        y, x = np.indices(self.box[:, :, 0].shape)
-
-        cx, cy = self.box.shape[0] / 2., self.box.shape[1] / 2.
+        #cx, cy = self.box.shape[0] / 2., self.box.shape[1] / 2.
+        cx, cy = self.boxshape0 / 2., self.boxshape1 / 2.
 
         self.cx = cx
         self.cy = cy
@@ -149,9 +182,10 @@ class XMMSimulator(object):
 
         thetas = np.linspace(0., 22., nthetas)
 
-        theta_image = np.hypot(x - cx, y - cy) * pixsize  # arcmin
+        theta_image = np.hypot(x - cx, y - cy) * self.pixsize  # arcmin
 
-        nene_ori = self.box.shape[2]
+        #nene_ori = self.box.shape[2]
+        nene_ori = self.boxshape2
 
         ene_lo, ene_hi = self.box_ene[:nene_ori], self.box_ene[1:]
 
@@ -562,21 +596,36 @@ class XMMSimulator(object):
         :param NH: Absorption column density
         :type NH: float
         """
+        if self.box:
+            print('# Compute model box...')
+            phot_box_ima = gen_phot_box(self,
+                                        tsim=self.tsim,
+                                        with_skybkg=withskybkg,
+                                        lhb=lhb,
+                                        ght=ght,
+                                        ghn=ghn,
+                                        cxb=cxb,
+                                        NH=NH,
+                                        abund=self.abund)
 
-        print('# Compute model box...')
-        phot_box_ima = gen_phot_box(self,
-                                    tsim=self.tsim,
-                                    with_skybkg=withskybkg,
-                                    lhb=lhb,
-                                    ght=ght,
-                                    ghn=ghn,
-                                    cxb=cxb,
-                                    NH=NH,
-                                    abund=self.abund)
+            print('# Generate sky events...')
+            X_evt, Y_evt, chan_evt = gen_evt_list(self,
+                                                  phot_box_ima=phot_box_ima)
 
-        print('# Generate sky events...')
-        X_evt, Y_evt, chan_evt = gen_evt_list(self,
-                                              phot_box_ima=phot_box_ima)
+        elif self.evtfile_input:
+            X_evt, Y_evt, chan_evt = gen_phot_evtlist(self,
+                                                      tsim=self.tsim,
+                                                      with_skybkg=withskybkg,
+                                                      lhb=lhb,
+                                                      ght=ght,
+                                                      ghn=ghn,
+                                                      cxb=cxb,
+                                                      NH=NH,
+                                                      abund=self.abund)
+
+        else:
+            print('You need to provide either a box or an ideal event file.')
+            return
 
         if self.fwc_spec is None:
             print('FWC events not extracted yet, skipping QPB event generation')

--- a/build/lib/xmm_simulator/simulator.py
+++ b/build/lib/xmm_simulator/simulator.py
@@ -64,7 +64,7 @@ class XMMSimulator(object):
 
             self.box = fb[0].data
 
-            self.pixsize = self.box_size / self.box.shape[0]
+            self.pixsize_ori = self.box_size / self.box.shape[0]
 
             self.boxshape0 = self.box.shape[0]
             self.boxshape1 = self.box.shape[1]
@@ -75,10 +75,10 @@ class XMMSimulator(object):
         else:
             self.box = None
             self.evtfile_input = evtfile_input
-            self.boxshape0 = 100#512
-            self.boxshape1 = 100#512
-            self.boxshape2 = 99#495
-            self.pixsize = self.box_size / self.boxshape0
+            self.boxshape0 = 512#512
+            self.boxshape1 = 512#512
+            self.boxshape2 = 495#495
+            self.pixsize_ori = self.box_size / self.boxshape0
 
 
         if box_ene is None:
@@ -166,7 +166,7 @@ class XMMSimulator(object):
         Compute the ARFs for each point on the box
 
         """
-        #redefined by rseppi as self.pixsize
+        #redefined by rseppi as self.pixsize_ori
         #pixsize = self.box_size / self.box.shape[0]  # by default box size is 30 arcmin
 
         #y, x = np.indices(self.box[:, :, 0].shape)
@@ -182,7 +182,7 @@ class XMMSimulator(object):
 
         thetas = np.linspace(0., 22., nthetas)
 
-        theta_image = np.hypot(x - cx, y - cy) * self.pixsize  # arcmin
+        theta_image = np.hypot(x - cx, y - cy) * self.pixsize_ori  # arcmin
 
         #nene_ori = self.box.shape[2]
         nene_ori = self.boxshape2

--- a/build/lib/xmm_simulator/utils.py
+++ b/build/lib/xmm_simulator/utils.py
@@ -248,7 +248,7 @@ def set_wcs(xmmsim, type='mask'):
     if type == 'box':
         pixsize_ori = xmmsim.box_size / 60. / xmmsim.boxshape1  # degree
 
-        if xmmsim.box:
+        if xmmsim.box is not None:
             ima = xmmsim.box[:, :, 0]
             hdu = fits.PrimaryHDU(ima)
             header = hdu.header

--- a/build/lib/xmm_simulator/utils.py
+++ b/build/lib/xmm_simulator/utils.py
@@ -76,6 +76,22 @@ def calc_arf(theta, ebound_lo, ebound_hi, xmmsim):
 
     arf = area_ebound * vig_ebound * corr_ebound * filter_ebound * qeff_ebound
 
+    if np.any(arf<0.):
+
+        print('WARNING: some negative ARF value detected, set to zero')
+
+        negarf = np.where(arf<0.)
+
+        arf[negarf] = 0.
+
+    if np.any(np.isnan(arf)):
+
+        print('WARNING: some NaN ARF value detected, set to zero')
+
+        nanarf = np.where(np.isnan(arf))
+
+        arf[nanarf] = 0.
+
     return arf
 
 
@@ -224,29 +240,29 @@ def set_wcs(xmmsim, type='mask'):
 
     inmask.close()
 
-    ima = xmmsim.box[:, :, 0]
-
-    hdu = fits.PrimaryHDU(ima)
-
     npix_mask = mask.shape[0]
 
-    npix_box = ima.shape[0]
+    #npix_box = ima.shape[0]
+    npix_box = xmmsim.boxshape0
 
     if type == 'box':
-        header = hdu.header
+        pixsize_ori = xmmsim.box_size / 60. / xmmsim.boxshape1  # degree
 
-        pixsize_ori = xmmsim.box_size / 60. / xmmsim.box.shape[1] # degree
+        if xmmsim.box:
+            ima = xmmsim.box[:, :, 0]
+            hdu = fits.PrimaryHDU(ima)
+            header = hdu.header
+        else:
+            header = fits.Header()
 
         header['CDELT1'] = - pixsize_ori
         header['CDELT2'] = pixsize_ori
         header['CRPIX1'] = head_mask['CRPIX1'] * npix_box / npix_mask
         header['CRPIX2'] = head_mask['CRPIX2'] * npix_box / npix_mask
-
         header['CTYPE1'] = head_mask['CTYPE1']
         header['CTYPE2'] = head_mask['CTYPE2']
         header['CRVAL1'] = 0.
         header['CRVAL2'] = 0.
-
         wcs = WCS(header)
 
     else:

--- a/xmm_simulator/event_file.py
+++ b/xmm_simulator/event_file.py
@@ -70,7 +70,7 @@ def gen_phot_box(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=None, c
     xori = np.arange(0, xmmsim.box.shape[1], 1)
     yori = np.arange(0, xmmsim.box.shape[0], 1)
 
-    pixsize_ori = xmmsim.box_size / xmmsim.box.shape[1] # arcmin
+    #pixsize_ori = xmmsim.box_size / xmmsim.box.shape[1] # arcmin
 
     cx, cy = npix_out / 2., npix_out / 2.
 
@@ -104,7 +104,7 @@ def gen_phot_box(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=None, c
 
         modphabs.NH = NH
 
-        modsource = pixsize_ori**2 * (modlhb + modphabs * (modgh + modcxb))
+        modsource = xmmsim.pixsize_ori**2 * (modlhb + modphabs * (modgh + modcxb))
 
         skybkg_spectrum = modsource(xmmsim.box_ene_mean)
 
@@ -121,9 +121,9 @@ def gen_phot_box(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=None, c
 
     nene = len(ene) - 1
 
-    xnew = (np.arange(0, npix_out, 1) - cx) * pixsize / pixsize_ori
+    xnew = (np.arange(0, npix_out, 1) - cx) * pixsize / xmmsim.pixsize_ori
 
-    ynew = (np.arange(0, npix_out, 1) - cy) * pixsize / pixsize_ori
+    ynew = (np.arange(0, npix_out, 1) - cy) * pixsize / xmmsim.pixsize_ori
 
     phot_box_ima = np.empty((npix_out,npix_out,nene))
 
@@ -138,7 +138,7 @@ def gen_phot_box(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=None, c
 
         finterp = RectBivariateSpline(yori - cy_ori, xori - cx_ori, ima.T)
 
-        ima_newpix = finterp(xnew, ynew).T * (pixsize / pixsize_ori)**2 # phot/cm2/s/keV
+        ima_newpix = finterp(xnew, ynew).T * (pixsize / xmmsim.pixsize_ori)**2 # phot/cm2/s/keV
 
         phot_box_ima[:,:,i] = psf_convole(ima_newpix, pixsize, xmmsim) * mask
 
@@ -201,7 +201,7 @@ def gen_phot_evtlist(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=Non
     yori = np.arange(0, xmmsim.boxshape0, 1)
 
     #pixsize_ori = xmmsim.box_size / xmmsim.box.shape[1] # arcmin
-    pixsize_ori = xmmsim.box_size / xmmsim.boxshape1 # arcmin
+    #pixsize_ori = xmmsim.box_size / xmmsim.boxshape1 # arcmin
 
     cx, cy = npix_out / 2., npix_out / 2.
 
@@ -235,7 +235,7 @@ def gen_phot_evtlist(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=Non
 
         modphabs.NH = NH
 
-        modsource = pixsize_ori**2 * (modlhb + modphabs * (modgh + modcxb))
+        modsource = xmmsim.pixsize_ori**2 * (modlhb + modphabs * (modgh + modcxb))
 
         skybkg_spectrum = modsource(xmmsim.box_ene_mean)
 
@@ -255,9 +255,9 @@ def gen_phot_evtlist(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=Non
 
     nene = len(ene) - 1
 
-    xnew = (np.arange(0, npix_out, 1) - cx) * pixsize / pixsize_ori
+    xnew = (np.arange(0, npix_out, 1) - cx) * pixsize / xmmsim.pixsize_ori
 
-    ynew = (np.arange(0, npix_out, 1) - cy) * pixsize / pixsize_ori
+    ynew = (np.arange(0, npix_out, 1) - cy) * pixsize / xmmsim.pixsize_ori
 
     phot_box_ima = np.empty((npix_out,npix_out,nene))
 
@@ -274,7 +274,7 @@ def gen_phot_evtlist(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=Non
 
         finterp = RectBivariateSpline(yori - cy_ori, xori - cx_ori, ima.T)
 
-        ima_newpix = finterp(xnew, ynew).T * (pixsize / pixsize_ori)**2 # phot/cm2/s/keV
+        ima_newpix = finterp(xnew, ynew).T * (pixsize / xmmsim.pixsize_ori)**2 # phot/cm2/s/keV
 
         phot_box_ima[:,:,i] = psf_convole(ima_newpix, pixsize, xmmsim) * mask
 
@@ -357,19 +357,19 @@ def gen_phot_evtlist(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=Non
     #and also shift 0,0 coordinates in x_pix to the central 256,256 pixel
     ra_evt = np.array(f_pyxsim['data']['xsky'][()])
     dec_evt = np.array(f_pyxsim['data']['ysky'][()])
-    x_pix = np.array(f_pyxsim['data']['xsky'][()]*60./pixsize_ori + xoffset, dtype=int)
-    y_pix = np.array(f_pyxsim['data']['ysky'][()]*60./pixsize_ori + yoffset, dtype=int)
+    x_pix = np.round(f_pyxsim['data']['xsky'][()]*60./xmmsim.pixsize_ori + xoffset).astype(int)
+    y_pix = np.round(f_pyxsim['data']['ysky'][()]*60./xmmsim.pixsize_ori + yoffset).astype(int)
     energy = f_pyxsim['data']['eobs'][()]
 
     #prepare arrays to output pixels and energy of cluster evts
-    X_clu, Y_clu, chan_evt_clu = np.array([]), np.array([]), np.array([])
+    X_clu, Y_clu, chan_evt_clu = [], [], []
     #Loop on the output pixels
     print('Working on CLU...')
     print('EFFAREA:', eff_area)
     print('Nevt to start:', len(energy))
 
     print('pixsize',pixsize)
-    print('pixsize_ori',pixsize_ori)
+    print('pixsize_ori',xmmsim.pixsize_ori)
 
     for ii,xx in tqdm(enumerate(xori), total=len(xori)): #loop on xori because that's where the arf is computed
         for jj,yy in enumerate(yori):
@@ -393,26 +393,31 @@ def gen_phot_evtlist(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=Non
 
                     #select fraction of evts based on ARFs ratio and texp ratio
                     selfrac = xmmsim.all_arfs[yy,xx,kk]/eff_area * tsim/texp_evt #make sure you select correct arf here
+                    #selfrac=0.1
                     N_evts_out = np.random.poisson(len(evts_this_ene)*selfrac )
                     #N_evts_out = int( len(evts_this_ene)*selfrac )
                     #if xmmsim.all_arfs[ii,jj,kk]>100:
                         #print('ARF_here:', xmmsim.all_arfs[ii,jj,kk])
                         #print('ARFs ratio:', xmmsim.all_arfs[ii,jj,kk]/eff_area, 'texp_ratio:', tsim/texp_evt)
                         #print(selfrac, N_evts_out)
-                    ids = np.random.choice(range(len(evts_this_ene)), size=N_evts_out, replace=True)
+                    if N_evts_out>len(evts_this_ene):
+                        replace = True
+                    else:
+                        replace = False
+                    ids = np.random.choice(range(len(evts_this_ene)), size=N_evts_out, replace=replace)
                     evts_clu_out = evts_this_ene[ids]
                     if len(evts_clu_out)>0:
                         #print('      Nevt after arfs,exp cut:', len(evts_clu_out))
 
                         #Loop on evts to apply rmf
-                        evts_clu_out_rmf = np.zeros_like(evts_clu_out)
+                        evts_clu_out_rmf = []
                         for aa,evt in enumerate(evts_clu_out):
                             channel = rmf.energy_to_channel(evt)
                             prob_dist = rmf.matrix.T[channel]  #or rmf.matrix.T ? Confirmed with Eckert, it's .T (P(E) tail at low E)
                             # Normalize probabilities
                             prob_dist /= np.sum(prob_dist)
                             # Sample new energy based on the probability distribution
-                            evts_clu_out_rmf[aa] = np.random.choice(emb, p=prob_dist)
+                            evts_clu_out_rmf.append(np.random.choice(emb, p=prob_dist))
                         ra_pix_out = ra_pix_ene[ids]
                         dec_pix_out = dec_pix_ene[ids]
 
@@ -424,10 +429,18 @@ def gen_phot_evtlist(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=Non
                         #print('xx_out:',xx_out)
                         #print('yy:',yy)
                         #print('yy_out:',yy_out)
-                        X_clu = np.append(X_clu, xx_out)
-                        Y_clu = np.append(Y_clu, yy_out)
-                        chan_evt_clu = np.append(chan_evt_clu, evts_clu_out_rmf)
+                        X_clu.append(xx_out)
+                        Y_clu.append(yy_out)
+                        chan_evt_clu.append(evts_clu_out_rmf)
+                        #X_clu = np.append(X_clu, xx_out)
+                        #Y_clu = np.append(Y_clu, yy_out)
+                        #chan_evt_clu = np.append(chan_evt_clu, evts_clu_out_rmf)
         print('Cumulative N CLU evt pix:', len(X_clu))
+
+    # Concatenate
+    X_clu = np.concatenate(X_clu)
+    Y_clu = np.concatenate(Y_clu)
+    chan_evt_clu = np.concatenate(chan_evt_clu)
 
     #Add PSF
     print('Xclu', X_clu)

--- a/xmm_simulator/event_file.py
+++ b/xmm_simulator/event_file.py
@@ -10,6 +10,9 @@ import progressbar
 from datetime import datetime
 import h5py as h5
 from tqdm import tqdm
+import time
+from collections import defaultdict
+import gc
 
 lhb_ref = 2.92859e-06 # MACS 0949 sky bkg parameters
 ght_ref = 0.220899
@@ -145,6 +148,19 @@ def gen_phot_box(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=None, c
     return phot_box_ima
 
 
+def sample_rmf(energies, energy_to_channel, rmf_matrix_transposed, emb):
+    '''
+    Function to convolve an array of energies with the RMF
+    '''
+    evts_clu_out_rmf = np.empty(len(energies), dtype=emb.dtype)
+    for bb, evt in enumerate(energies):
+        channel = energy_to_channel(evt)
+        prob_dist = rmf_matrix_transposed[channel]  # or rmf.matrix.T ? Confirmed with Eckert, it's .T (P(E) tail at low E)
+        # Normalize probabilities
+        prob_dist /= np.sum(prob_dist)
+        # Sample new energy based on the probability distribution
+        evts_clu_out_rmf[bb] = np.random.choice(emb, p=prob_dist)
+    return evts_clu_out_rmf
 
 
 
@@ -182,19 +198,23 @@ def gen_phot_evtlist(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=Non
 
         return
 
+    #Get RMF file
+    rmf_file = get_data_file_path('rmfs/%s.rmf' % (xmmsim.instrument))
+    rmf = OGIPResponse(rsp_file=rmf_file)
+    nchan = len(rmf.monte_carlo_energies) - 1
+    mc_ene = (rmf.monte_carlo_energies[:nchan] + rmf.monte_carlo_energies[1:]) / 2.
+    bin_width = rmf.monte_carlo_energies[1:] - rmf.monte_carlo_energies[:nchan]
+    emb = (rmf.ebounds[1:] + rmf.ebounds[:-1]) / 2.
+    ene_to_chan = rmf.energy_to_channel
+    rmf_mat_T = rmf.matrix.T
+
     # Get mask file
     mask_file = get_data_file_path('imgs/%s_mask.fits.gz' % (xmmsim.instrument))
-
     inmask = fits.open(mask_file)
-
     mask = inmask[1].data
-
     pixsize = inmask[1].header['CDELT2'] * 60.  # arcmin
-
     inmask.close()
-
     npix_out = mask.shape[0]
-
     ene = xmmsim.box_ene
 
     xori = np.arange(0, xmmsim.boxshape1, 1)
@@ -261,92 +281,89 @@ def gen_phot_evtlist(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=Non
 
     phot_box_ima = np.empty((npix_out,npix_out,nene))
 
-    print('Working BKG and AGN: PSF...')
-    bar = progressbar.ProgressBar()
+    pts_bkg_bool = False
+    if np.sum(phot_box)>0:
+        pts_bkg_bool = True
+        print('Working BKG and AGN: PSF...')
+        bar = progressbar.ProgressBar()
 
-    for i in bar(range(nene)):
-        # Select box data in the chosen energy band
-        ima = phot_box[:, :, i]
+        for i in bar(range(nene)):
+            # Select box data in the chosen energy band
+            ima = phot_box[:, :, i]
 
-        # Recast box shape into output image shape
-        #cx_ori, cy_ori =  xmmsim.box.shape[1]/2. , xmmsim.box.shape[0]/2.
-        cx_ori, cy_ori =  xmmsim.boxshape1/2. , xmmsim.boxshape0/2.
+            # Recast box shape into output image shape
+            #cx_ori, cy_ori =  xmmsim.box.shape[1]/2. , xmmsim.box.shape[0]/2.
+            cx_ori, cy_ori =  xmmsim.boxshape1/2. , xmmsim.boxshape0/2.
 
-        finterp = RectBivariateSpline(yori - cy_ori, xori - cx_ori, ima.T)
+            finterp = RectBivariateSpline(yori - cy_ori, xori - cx_ori, ima.T)
 
-        ima_newpix = finterp(xnew, ynew).T * (pixsize / xmmsim.pixsize_ori)**2 # phot/cm2/s/keV
+            ima_newpix = finterp(xnew, ynew).T * (pixsize / xmmsim.pixsize_ori)**2 # phot/cm2/s/keV
 
-        phot_box_ima[:,:,i] = psf_convole(ima_newpix, pixsize, xmmsim) * mask
+            phot_box_ima[:,:,i] = psf_convole(ima_newpix, pixsize, xmmsim) * mask
 
 
-    #start of gen_evt_list
-    rmf_file = get_data_file_path('rmfs/%s.rmf' % (xmmsim.instrument))
+        #start of gen_evt_list
+        ima_tot = np.sum(phot_box_ima, axis=2) * xmmsim.box_ene_width
+        print('min ima_tot:', np.min(ima_tot))
+        ima_tot[ima_tot<0]=0
+        photon_map = np.random.poisson(ima_tot)
 
-    rmf = OGIPResponse(rsp_file=rmf_file)
+        yp, xp = np.indices(photon_map.shape)
 
-    nchan = len(rmf.monte_carlo_energies) - 1
+        nonz = np.where(photon_map > 0)
 
-    mc_ene = (rmf.monte_carlo_energies[:nchan] + rmf.monte_carlo_energies[1:]) / 2.
+        X_evt = np.repeat(xp[nonz], photon_map[nonz])
 
-    bin_width = rmf.monte_carlo_energies[1:] - rmf.monte_carlo_energies[:nchan]
+        Y_evt = np.repeat(yp[nonz], photon_map[nonz])
 
-    emb = (rmf.ebounds[1:] + rmf.ebounds[:-1]) / 2.
+        chan_evt = np.array([])
 
-    ima_tot = np.sum(phot_box_ima, axis=2) * xmmsim.box_ene_width
-    print('min ima_tot:', np.min(ima_tot))
-    ima_tot[ima_tot<0]=0
-    photon_map = np.random.poisson(ima_tot)
+        npix_active = len(xp[nonz])
 
-    yp, xp = np.indices(photon_map.shape)
+        print('Working on BKG and AGN: RMF...')
+        bar = progressbar.ProgressBar()
+        chan_evt = []
+        for i in bar(range(npix_active)):
+            tx = xp[nonz][i]
+            ty = yp[nonz][i]
 
-    nonz = np.where(photon_map > 0)
+            nphot_pix = photon_map[nonz][i]
 
-    X_evt = np.repeat(xp[nonz], photon_map[nonz])
+            phot_spec = phot_box_ima[ty, tx, :]
 
-    Y_evt = np.repeat(yp[nonz], photon_map[nonz])
+            # Interpolate to the proper channels
+            finterp_spec = interp1d(xmmsim.box_ene_mean, phot_spec, fill_value='extrapolate')
 
-    chan_evt = np.array([])
+            spec_interp = finterp_spec(mc_ene)
 
-    npix_active = len(xp[nonz])
+            wronginterp = np.where(spec_interp < 0.)
 
-    print('Working on BKG and AGN: RMF...')
-    bar = progressbar.ProgressBar()
+            spec_interp[wronginterp] = 0.
 
-    for i in bar(range(npix_active)):
-        tx = xp[nonz][i]
-        ty = yp[nonz][i]
+            # Convolve with RMF
+            spec_conv = rmf.convolve(spec_interp * bin_width)
 
-        nphot_pix = photon_map[nonz][i]
+            spec_prob = spec_conv / np.sum(spec_conv)
 
-        phot_spec = phot_box_ima[ty, tx, :]
+            evts = np.random.choice(emb, p=spec_prob, size=nphot_pix)
 
-        # Interpolate to the proper channels
-        finterp_spec = interp1d(xmmsim.box_ene_mean, phot_spec, fill_value='extrapolate')
-
-        spec_interp = finterp_spec(mc_ene)
-
-        wronginterp = np.where(spec_interp < 0.)
-
-        spec_interp[wronginterp] = 0.
-
-        # Convolve with RMF
-        spec_conv = rmf.convolve(spec_interp * bin_width)
-
-        spec_prob = spec_conv / np.sum(spec_conv)
-
-        evts = np.random.choice(emb, p=spec_prob, size=nphot_pix)
-
-        chan_evt = np.append(chan_evt, evts)
-
-    ############################## END AGN+BKG ##############################
-    print('Nevt from BKG and PNT:', len(chan_evt))
+            chan_evt.append(evts)
+        chan_evt = np.concatenate(chan_evt)
+        ############################## END AGN+BKG ##############################
+        print('Nevt from BKG and PNT:', len(chan_evt))
 
     #NOW X_evt, Y_evt, chan_evt contain AGN and BKG events
     #Let's add the cluster events by downgrading pyxsim input events
     #Read evtfile from pyxsim and its properties
-    f_pyxsim = h5.File(xmmsim.evtfile_input,'r')
-    eff_area = f_pyxsim['parameters']['area'][()]
-    texp_evt = f_pyxsim['parameters']['exp_time'][()]
+    t0 = time.time()
+    with h5.File(xmmsim.evtfile_input, 'r') as f_pyxsim:
+        eff_area = f_pyxsim['parameters']['area'][()]
+        texp_evt = f_pyxsim['parameters']['exp_time'][()]
+        x_pix_out = np.floor(f_pyxsim['data']['xsky'][()] * 60. / pixsize + cx).astype(int)
+        y_pix_out = np.floor(f_pyxsim['data']['ysky'][()] * 60. / pixsize + cy).astype(int)
+        energy = f_pyxsim['data']['eobs'][()]
+    texp_ratio = tsim / texp_evt
+
     xoffset = int(xori[int(len(xori)/2.)])
     yoffset = int(xori[int(len(yori)/2.)])
     print('xoffset:', xoffset)
@@ -355,112 +372,125 @@ def gen_phot_evtlist(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=Non
     print('cy:', cy)
     # position in pixels = position in deg / pixsize
     #and also shift 0,0 coordinates in x_pix to the central 256,256 pixel
-    ra_evt = np.array(f_pyxsim['data']['xsky'][()])
-    dec_evt = np.array(f_pyxsim['data']['ysky'][()])
-    x_pix = np.round(f_pyxsim['data']['xsky'][()]*60./xmmsim.pixsize_ori + xoffset).astype(int)
-    y_pix = np.round(f_pyxsim['data']['ysky'][()]*60./xmmsim.pixsize_ori + yoffset).astype(int)
-    energy = f_pyxsim['data']['eobs'][()]
 
     #prepare arrays to output pixels and energy of cluster evts
     X_clu, Y_clu, chan_evt_clu = [], [], []
     #Loop on the output pixels
     print('Working on CLU...')
     print('EFFAREA:', eff_area)
-    print('Nevt to start:', len(energy))
+    print('Texp:', texp_evt)
+    Nstart = len(energy)
+    print('Nevt to start:', Nstart)
 
     print('pixsize',pixsize)
     print('pixsize_ori',xmmsim.pixsize_ori)
 
+
+    #Add PSF
+    print('Adding PSF...')
+    x_clu_blurred, y_clu_blurred = psf_convole_evt(x_pix_out, y_pix_out, pixsize, xmmsim)
+    sel = (x_clu_blurred>0) & (x_clu_blurred<899) & (y_clu_blurred>0) & (y_clu_blurred<899)
+    x_clu_blurred, y_clu_blurred = x_clu_blurred[sel], y_clu_blurred[sel]
+    energy = energy[sel]
+    ra_pix_blurred = (x_clu_blurred - cx) * pixsize
+    dec_pix_blurred = (y_clu_blurred - cy) * pixsize
+    x_pix_blurred = np.floor(ra_pix_blurred / xmmsim.pixsize_ori + xoffset).astype(int)
+    y_pix_blurred = np.floor(dec_pix_blurred / xmmsim.pixsize_ori + yoffset).astype(int)
+    N_blurred = len(x_pix_blurred)
+    print('Kept', N_blurred, 'evts, fraction:',N_blurred/Nstart)
+    t1 = time.time()
+    print('It took', t1-t0, 'sec')
+
+
+    #Apply camera mask
+    print('Applying camera mask...')
+    valid_photons = mask[y_clu_blurred, x_clu_blurred] == 1  # Boolean mask
+    x_pix_blurred = x_pix_blurred[valid_photons]
+    y_pix_blurred = y_pix_blurred[valid_photons]
+    x_clu_blurred = x_clu_blurred[valid_photons]
+    y_clu_blurred = y_clu_blurred[valid_photons]
+    energy = energy[valid_photons]
+    N_mask = len(energy)
+    print('Kept', N_mask, 'evts, fraction:',N_mask/N_blurred, 'to total:',N_mask/Nstart)
+    t2_ = time.time()
+    print('Took',t2_-t1,'sec, total:',t2_-t0)
+
+    print('Building photon map...')
+    photon_map = defaultdict(list)
+    for x_p, y_p, e, x_cl, y_cl in zip(x_pix_blurred, y_pix_blurred, energy, x_clu_blurred, y_clu_blurred):
+        photon_map[(x_p, y_p)].append((e, x_cl, y_cl))
+    for key in photon_map:
+        photon_map[key] = np.array(photon_map[key])
+    t2 = time.time()
+
+    del x_pix_blurred
+    del y_pix_blurred
+    del energy
+    del x_clu_blurred
+    del y_clu_blurred
+    gc.collect()
+
+    print('Took',t2-t2_,'sec, total:',t2-t0)
+
     for ii,xx in tqdm(enumerate(xori), total=len(xori)): #loop on xori because that's where the arf is computed
         for jj,yy in enumerate(yori):
             #Select the events falling within this pixel
-            sel_evt = (x_pix==xx) & (y_pix==yy)
-            energy_pix = energy[sel_evt]
-            ra_pix = ra_evt[sel_evt]
-            dec_pix = dec_evt[sel_evt]
-            #if len(energy_pix)>49:
-                #print('Nevt in this pix:', len(energy_pix))
+            pix_entries = photon_map.get((xx, yy), [])
+            if len(pix_entries) == 0:
+                continue
+            energy_pix = pix_entries[:, 0]
+            x_clu_blurred_pix = pix_entries[:, 1].astype(int)
+            y_clu_blurred_pix = pix_entries[:, 2].astype(int)
 
             #Loop on energy bounds
             for kk,(elow, ehigh) in enumerate(zip(xmmsim.box_ene[:-1], xmmsim.box_ene[1:])):
                 #Select events within these bounds
-                selevts = (energy_pix>=elow) & (energy_pix<ehigh)
-                evts_this_ene = energy_pix[selevts]
-                ra_pix_ene = ra_pix[selevts]
-                dec_pix_ene = dec_pix[selevts]
-                if len(evts_this_ene)>0:
-                    #print('  Nevt at this ene:', len(evts_this_ene))
+                sel_ene = (energy_pix>=elow) & (energy_pix<ehigh)
+                sel_idx = np.where(sel_ene)[0]
+                if len(sel_idx) == 0:
+                    continue
+                evts_this_ene = energy_pix[sel_ene]
 
-                    #select fraction of evts based on ARFs ratio and texp ratio
-                    selfrac = xmmsim.all_arfs[yy,xx,kk]/eff_area * tsim/texp_evt #make sure you select correct arf here
-                    #selfrac=0.1
-                    N_evts_out = np.random.poisson(len(evts_this_ene)*selfrac )
-                    #N_evts_out = int( len(evts_this_ene)*selfrac )
-                    #if xmmsim.all_arfs[ii,jj,kk]>100:
-                        #print('ARF_here:', xmmsim.all_arfs[ii,jj,kk])
-                        #print('ARFs ratio:', xmmsim.all_arfs[ii,jj,kk]/eff_area, 'texp_ratio:', tsim/texp_evt)
-                        #print(selfrac, N_evts_out)
-                    if N_evts_out>len(evts_this_ene):
-                        replace = True
-                    else:
-                        replace = False
-                    ids = np.random.choice(range(len(evts_this_ene)), size=N_evts_out, replace=replace)
-                    evts_clu_out = evts_this_ene[ids]
-                    if len(evts_clu_out)>0:
-                        #print('      Nevt after arfs,exp cut:', len(evts_clu_out))
+                #select fraction of evts based on ARFs ratio and texp ratio
+                selfrac = xmmsim.all_arfs[yy,xx,kk]/eff_area * texp_ratio #make sure you select correct arf here
+                N_evts_out = np.random.poisson(len(evts_this_ene)*selfrac )
+                if N_evts_out>len(evts_this_ene):
+                    replace = True
+                else:
+                    replace = False
+                ids = np.random.choice(range(len(evts_this_ene)), size=N_evts_out, replace=replace)
+                final_idx = sel_idx[ids]
+                evts_clu_out = evts_this_ene[ids]
+                if len(evts_clu_out)>0:
+                    #Loop on evts to apply rmf
+                    evts_clu_out_rmf = sample_rmf(evts_clu_out, ene_to_chan, rmf_mat_T, emb)
 
-                        #Loop on evts to apply rmf
-                        evts_clu_out_rmf = []
-                        for aa,evt in enumerate(evts_clu_out):
-                            channel = rmf.energy_to_channel(evt)
-                            prob_dist = rmf.matrix.T[channel]  #or rmf.matrix.T ? Confirmed with Eckert, it's .T (P(E) tail at low E)
-                            # Normalize probabilities
-                            prob_dist /= np.sum(prob_dist)
-                            # Sample new energy based on the probability distribution
-                            evts_clu_out_rmf.append(np.random.choice(emb, p=prob_dist))
-                        ra_pix_out = ra_pix_ene[ids]
-                        dec_pix_out = dec_pix_ene[ids]
+                    xx_out = x_clu_blurred_pix[final_idx]
+                    yy_out = y_clu_blurred_pix[final_idx]
+                    X_clu.append(xx_out)
+                    Y_clu.append(yy_out)
+                    chan_evt_clu.append(evts_clu_out_rmf)
+        if ii%10==0:
+            tt = time.time()
+            print('Up to xx=',ii,':',tt-t2, 'total:',tt-t0)
+            print('Cumulative N CLU evt pix:', len(X_clu))
 
-                        xx_out = np.round(ra_pix_out*60./pixsize + cx).astype(int)
-                        yy_out = np.round(dec_pix_out*60./pixsize + cy).astype(int)
-                        #xx_out = int(xx * pixsize_ori / pixsize)
-                        #yy_out = int(yy * pixsize_ori / pixsize)
-                        #print('xx:',xx)
-                        #print('xx_out:',xx_out)
-                        #print('yy:',yy)
-                        #print('yy_out:',yy_out)
-                        X_clu.append(xx_out)
-                        Y_clu.append(yy_out)
-                        chan_evt_clu.append(evts_clu_out_rmf)
-                        #X_clu = np.append(X_clu, xx_out)
-                        #Y_clu = np.append(Y_clu, yy_out)
-                        #chan_evt_clu = np.append(chan_evt_clu, evts_clu_out_rmf)
-        print('Cumulative N CLU evt pix:', len(X_clu))
+    del photon_map
+    gc.collect()
 
     # Concatenate
     X_clu = np.concatenate(X_clu)
     Y_clu = np.concatenate(Y_clu)
     chan_evt_clu = np.concatenate(chan_evt_clu)
 
-    #Add PSF
-    print('Xclu', X_clu)
-    X_clu_blurred, Y_clu_blurred = psf_convole_evt(X_clu, Y_clu, pixsize, xmmsim)
-    sel = (X_clu_blurred>0) & (X_clu_blurred<899) & (Y_clu_blurred>0) & (Y_clu_blurred<899)
-    X_clu_blurred, Y_clu_blurred = X_clu_blurred[sel], Y_clu_blurred[sel]
-    chan_evt_clu = chan_evt_clu[sel]
-    print('Xclu_blurred', X_clu_blurred)
-
-    #Apply camera mask
-    valid_photons = mask[np.array(Y_clu_blurred, dtype=int), np.array(X_clu_blurred, dtype=int)] == 1  # Boolean mask
-    X_clu_filtered = X_clu_blurred[valid_photons]
-    Y_clu_filtered = Y_clu_blurred[valid_photons]
-    chan_evt_clu_filtered = chan_evt_clu[valid_photons]
-    print('N CLU evt:', len(X_clu_filtered))
-    X_evt = np.append(X_evt, X_clu_filtered)
-    Y_evt = np.append(Y_evt, Y_clu_filtered)
-    chan_evt = np.append(chan_evt, chan_evt_clu_filtered)
-    return X_evt, Y_evt, chan_evt
-
+    print('N CLU evt:', len(X_clu))
+    if pts_bkg_bool:
+        X_evt = np.append(X_evt, X_clu)
+        Y_evt = np.append(Y_evt, Y_clu)
+        chan_evt = np.append(chan_evt, chan_evt_clu)
+        return X_evt, Y_evt, chan_evt
+    else:
+        return X_clu, Y_clu, chan_evt_clu
 
 # test by simulating the number of photons first and then drawing the energy
 def gen_evt_list(xmmsim, phot_box_ima):

--- a/xmm_simulator/event_file.py
+++ b/xmm_simulator/event_file.py
@@ -1,13 +1,15 @@
 import numpy as np
 from astropy.io import fits
 from .utils import get_data_file_path
-from .imaging import psf_convole
+from .imaging import psf_convole, psf_convole_evt
 from .background import tot_area
 from scipy.interpolate import interp1d, RectBivariateSpline
 from threeML.utils.OGIP.response import OGIPResponse
 from threeML import APEC, Powerlaw, PhAbs
 import progressbar
 from datetime import datetime
+import h5py as h5
+from tqdm import tqdm
 
 lhb_ref = 2.92859e-06 # MACS 0949 sky bkg parameters
 ght_ref = 0.220899
@@ -141,6 +143,310 @@ def gen_phot_box(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=None, c
         phot_box_ima[:,:,i] = psf_convole(ima_newpix, pixsize, xmmsim) * mask
 
     return phot_box_ima
+
+
+
+
+
+def gen_phot_evtlist(xmmsim, tsim, with_skybkg=True, lhb=None, ght=None, ghn=None, cxb=None, NH=None, abund='angr'):
+    """
+    Generate a box expectation value in photon/keV , convolved with the PSF and multiplied by the detector mask
+    starting from an ideal event list (e.g. from pyxsim)
+    :param xmmsim: XMMSimulator
+    :param tsim: Simulation exposure time in sec
+    :return: photon box
+    """
+
+    if lhb is None:
+        lhb = lhb_ref
+
+    if ght is None:
+        ght = ght_ref
+
+    if ghn is None:
+        ghn = ghn_ref
+
+    if cxb is None:
+        if xmmsim.pts:
+            cxb = cxb_m13_unres
+
+        else:
+            cxb = cxb_ref
+
+    if NH is None:
+        NH = NH_ref
+
+
+    if xmmsim.all_arfs is None:
+        print('ARF cube not found, please compute ARFs first')
+
+        return
+
+    # Get mask file
+    mask_file = get_data_file_path('imgs/%s_mask.fits.gz' % (xmmsim.instrument))
+
+    inmask = fits.open(mask_file)
+
+    mask = inmask[1].data
+
+    pixsize = inmask[1].header['CDELT2'] * 60.  # arcmin
+
+    inmask.close()
+
+    npix_out = mask.shape[0]
+
+    ene = xmmsim.box_ene
+
+    xori = np.arange(0, xmmsim.boxshape1, 1)
+    yori = np.arange(0, xmmsim.boxshape0, 1)
+
+    #pixsize_ori = xmmsim.box_size / xmmsim.box.shape[1] # arcmin
+    pixsize_ori = xmmsim.box_size / xmmsim.boxshape1 # arcmin
+
+    cx, cy = npix_out / 2., npix_out / 2.
+
+    skybkg_spectrum = None
+
+    if with_skybkg:
+        modlhb = APEC()
+        modgh = APEC()
+        if abund=='aspl':
+            modlhb.abundance_table = 'Lodd09'
+            modgh.abundance_table = 'Lodd09'
+
+        modcxb = Powerlaw()
+
+        #modlhb.init_session()
+        #modgh.init_session()
+
+        modlhb.kT = 0.11
+        modlhb.K = lhb
+        modlhb.redshift = 0.
+        modgh.kT = ght
+        modgh.K = ghn
+        modgh.redshift = 0.
+        modcxb.index = -1.46
+        modcxb.K = cxb
+        modphabs = PhAbs()
+        if abund == 'aspl':
+            modphabs.abundance_table = 'ASPL'
+
+        #modphabs.init_xsect()
+
+        modphabs.NH = NH
+
+        modsource = pixsize_ori**2 * (modlhb + modphabs * (modgh + modcxb))
+
+        skybkg_spectrum = modsource(xmmsim.box_ene_mean)
+
+    # Get photons per channel
+    ############################## START AGN+BKG ##############################
+    #rseppi: Instead, create an empty photbox to store the AGN and the BKG
+    #phot_box = xmmsim.box * tsim * xmmsim.all_arfs
+    phot_box = np.zeros((xmmsim.boxshape0, xmmsim.boxshape1, len(ene)-1))  #len(ene)-1 ? Yes because ene is the edges
+
+    if xmmsim.pts:
+        phot_box = phot_box + xmmsim.box_pts
+
+    if with_skybkg:
+        for i in range(len(xmmsim.box_ene_mean)):
+
+            phot_box[:, :, i] = phot_box[:, :, i] + skybkg_spectrum[i] * tsim * xmmsim.all_arfs[:, :, i]
+
+    nene = len(ene) - 1
+
+    xnew = (np.arange(0, npix_out, 1) - cx) * pixsize / pixsize_ori
+
+    ynew = (np.arange(0, npix_out, 1) - cy) * pixsize / pixsize_ori
+
+    phot_box_ima = np.empty((npix_out,npix_out,nene))
+
+    print('Working BKG and AGN: PSF...')
+    bar = progressbar.ProgressBar()
+
+    for i in bar(range(nene)):
+        # Select box data in the chosen energy band
+        ima = phot_box[:, :, i]
+
+        # Recast box shape into output image shape
+        #cx_ori, cy_ori =  xmmsim.box.shape[1]/2. , xmmsim.box.shape[0]/2.
+        cx_ori, cy_ori =  xmmsim.boxshape1/2. , xmmsim.boxshape0/2.
+
+        finterp = RectBivariateSpline(yori - cy_ori, xori - cx_ori, ima.T)
+
+        ima_newpix = finterp(xnew, ynew).T * (pixsize / pixsize_ori)**2 # phot/cm2/s/keV
+
+        phot_box_ima[:,:,i] = psf_convole(ima_newpix, pixsize, xmmsim) * mask
+
+
+    #start of gen_evt_list
+    rmf_file = get_data_file_path('rmfs/%s.rmf' % (xmmsim.instrument))
+
+    rmf = OGIPResponse(rsp_file=rmf_file)
+
+    nchan = len(rmf.monte_carlo_energies) - 1
+
+    mc_ene = (rmf.monte_carlo_energies[:nchan] + rmf.monte_carlo_energies[1:]) / 2.
+
+    bin_width = rmf.monte_carlo_energies[1:] - rmf.monte_carlo_energies[:nchan]
+
+    emb = (rmf.ebounds[1:] + rmf.ebounds[:-1]) / 2.
+
+    ima_tot = np.sum(phot_box_ima, axis=2) * xmmsim.box_ene_width
+    print('min ima_tot:', np.min(ima_tot))
+    ima_tot[ima_tot<0]=0
+    photon_map = np.random.poisson(ima_tot)
+
+    yp, xp = np.indices(photon_map.shape)
+
+    nonz = np.where(photon_map > 0)
+
+    X_evt = np.repeat(xp[nonz], photon_map[nonz])
+
+    Y_evt = np.repeat(yp[nonz], photon_map[nonz])
+
+    chan_evt = np.array([])
+
+    npix_active = len(xp[nonz])
+
+    print('Working on BKG and AGN: RMF...')
+    bar = progressbar.ProgressBar()
+
+    for i in bar(range(npix_active)):
+        tx = xp[nonz][i]
+        ty = yp[nonz][i]
+
+        nphot_pix = photon_map[nonz][i]
+
+        phot_spec = phot_box_ima[ty, tx, :]
+
+        # Interpolate to the proper channels
+        finterp_spec = interp1d(xmmsim.box_ene_mean, phot_spec, fill_value='extrapolate')
+
+        spec_interp = finterp_spec(mc_ene)
+
+        wronginterp = np.where(spec_interp < 0.)
+
+        spec_interp[wronginterp] = 0.
+
+        # Convolve with RMF
+        spec_conv = rmf.convolve(spec_interp * bin_width)
+
+        spec_prob = spec_conv / np.sum(spec_conv)
+
+        evts = np.random.choice(emb, p=spec_prob, size=nphot_pix)
+
+        chan_evt = np.append(chan_evt, evts)
+
+    ############################## END AGN+BKG ##############################
+    print('Nevt from BKG and PNT:', len(chan_evt))
+
+    #NOW X_evt, Y_evt, chan_evt contain AGN and BKG events
+    #Let's add the cluster events by downgrading pyxsim input events
+    #Read evtfile from pyxsim and its properties
+    f_pyxsim = h5.File(xmmsim.evtfile_input,'r')
+    eff_area = f_pyxsim['parameters']['area'][()]
+    texp_evt = f_pyxsim['parameters']['exp_time'][()]
+    xoffset = int(xori[int(len(xori)/2.)])
+    yoffset = int(xori[int(len(yori)/2.)])
+    print('xoffset:', xoffset)
+    print('yoffset:', yoffset)
+    print('cx:', cx)
+    print('cy:', cy)
+    # position in pixels = position in deg / pixsize
+    #and also shift 0,0 coordinates in x_pix to the central 256,256 pixel
+    ra_evt = np.array(f_pyxsim['data']['xsky'][()])
+    dec_evt = np.array(f_pyxsim['data']['ysky'][()])
+    x_pix = np.array(f_pyxsim['data']['xsky'][()]*60./pixsize_ori + xoffset, dtype=int)
+    y_pix = np.array(f_pyxsim['data']['ysky'][()]*60./pixsize_ori + yoffset, dtype=int)
+    energy = f_pyxsim['data']['eobs'][()]
+
+    #prepare arrays to output pixels and energy of cluster evts
+    X_clu, Y_clu, chan_evt_clu = np.array([]), np.array([]), np.array([])
+    #Loop on the output pixels
+    print('Working on CLU...')
+    print('EFFAREA:', eff_area)
+    print('Nevt to start:', len(energy))
+
+    print('pixsize',pixsize)
+    print('pixsize_ori',pixsize_ori)
+
+    for ii,xx in tqdm(enumerate(xori), total=len(xori)): #loop on xori because that's where the arf is computed
+        for jj,yy in enumerate(yori):
+            #Select the events falling within this pixel
+            sel_evt = (x_pix==xx) & (y_pix==yy)
+            energy_pix = energy[sel_evt]
+            ra_pix = ra_evt[sel_evt]
+            dec_pix = dec_evt[sel_evt]
+            #if len(energy_pix)>49:
+                #print('Nevt in this pix:', len(energy_pix))
+
+            #Loop on energy bounds
+            for kk,(elow, ehigh) in enumerate(zip(xmmsim.box_ene[:-1], xmmsim.box_ene[1:])):
+                #Select events within these bounds
+                selevts = (energy_pix>=elow) & (energy_pix<ehigh)
+                evts_this_ene = energy_pix[selevts]
+                ra_pix_ene = ra_pix[selevts]
+                dec_pix_ene = dec_pix[selevts]
+                if len(evts_this_ene)>0:
+                    #print('  Nevt at this ene:', len(evts_this_ene))
+
+                    #select fraction of evts based on ARFs ratio and texp ratio
+                    selfrac = xmmsim.all_arfs[yy,xx,kk]/eff_area * tsim/texp_evt #make sure you select correct arf here
+                    N_evts_out = np.random.poisson(len(evts_this_ene)*selfrac )
+                    #N_evts_out = int( len(evts_this_ene)*selfrac )
+                    #if xmmsim.all_arfs[ii,jj,kk]>100:
+                        #print('ARF_here:', xmmsim.all_arfs[ii,jj,kk])
+                        #print('ARFs ratio:', xmmsim.all_arfs[ii,jj,kk]/eff_area, 'texp_ratio:', tsim/texp_evt)
+                        #print(selfrac, N_evts_out)
+                    ids = np.random.choice(range(len(evts_this_ene)), size=N_evts_out, replace=True)
+                    evts_clu_out = evts_this_ene[ids]
+                    if len(evts_clu_out)>0:
+                        #print('      Nevt after arfs,exp cut:', len(evts_clu_out))
+
+                        #Loop on evts to apply rmf
+                        evts_clu_out_rmf = np.zeros_like(evts_clu_out)
+                        for aa,evt in enumerate(evts_clu_out):
+                            channel = rmf.energy_to_channel(evt)
+                            prob_dist = rmf.matrix.T[channel]  #or rmf.matrix.T ? Confirmed with Eckert, it's .T (P(E) tail at low E)
+                            # Normalize probabilities
+                            prob_dist /= np.sum(prob_dist)
+                            # Sample new energy based on the probability distribution
+                            evts_clu_out_rmf[aa] = np.random.choice(emb, p=prob_dist)
+                        ra_pix_out = ra_pix_ene[ids]
+                        dec_pix_out = dec_pix_ene[ids]
+
+                        xx_out = np.round(ra_pix_out*60./pixsize + cx).astype(int)
+                        yy_out = np.round(dec_pix_out*60./pixsize + cy).astype(int)
+                        #xx_out = int(xx * pixsize_ori / pixsize)
+                        #yy_out = int(yy * pixsize_ori / pixsize)
+                        #print('xx:',xx)
+                        #print('xx_out:',xx_out)
+                        #print('yy:',yy)
+                        #print('yy_out:',yy_out)
+                        X_clu = np.append(X_clu, xx_out)
+                        Y_clu = np.append(Y_clu, yy_out)
+                        chan_evt_clu = np.append(chan_evt_clu, evts_clu_out_rmf)
+        print('Cumulative N CLU evt pix:', len(X_clu))
+
+    #Add PSF
+    print('Xclu', X_clu)
+    X_clu_blurred, Y_clu_blurred = psf_convole_evt(X_clu, Y_clu, pixsize, xmmsim)
+    sel = (X_clu_blurred>0) & (X_clu_blurred<899) & (Y_clu_blurred>0) & (Y_clu_blurred<899)
+    X_clu_blurred, Y_clu_blurred = X_clu_blurred[sel], Y_clu_blurred[sel]
+    chan_evt_clu = chan_evt_clu[sel]
+    print('Xclu_blurred', X_clu_blurred)
+
+    #Apply camera mask
+    valid_photons = mask[np.array(Y_clu_blurred, dtype=int), np.array(X_clu_blurred, dtype=int)] == 1  # Boolean mask
+    X_clu_filtered = X_clu_blurred[valid_photons]
+    Y_clu_filtered = Y_clu_blurred[valid_photons]
+    chan_evt_clu_filtered = chan_evt_clu[valid_photons]
+    print('N CLU evt:', len(X_clu_filtered))
+    X_evt = np.append(X_evt, X_clu_filtered)
+    Y_evt = np.append(Y_evt, Y_clu_filtered)
+    chan_evt = np.append(chan_evt, chan_evt_clu_filtered)
+    return X_evt, Y_evt, chan_evt
 
 
 # test by simulating the number of photons first and then drawing the energy

--- a/xmm_simulator/imaging.py
+++ b/xmm_simulator/imaging.py
@@ -71,9 +71,18 @@ def psf_convole_evt(Xevt, Yevt, pixsize, xmmsim):
     fpsf.close()
 
     num_photons = len(Xevt)  # Number of photons
+
     u = np.random.uniform(0, 1, num_photons)  # Uniform random numbers
+    #Analytical method
     #Draw offsets from the King's CDF
-    r_samples = r0 * np.sqrt((1 / u) ** (1 / (alpha - 1)) - 1)
+    #r_samples = r0 * np.sqrt((1 / u) ** (1 / (alpha - 1)) - 1)
+
+    #Numerical method
+    offsets = np.geomspace(1e-4, 50, 1000)
+    king_profile = (1 + (offsets / r0) ** 2) ** (-alpha)
+    king_cdf = np.cumsum(king_profile)/np.sum(king_profile)
+    r_samples = np.interp(u, king_cdf, offsets)
+
     theta_samples = np.random.uniform(0, 2 * np.pi, size=num_photons)  # Random angles
 
     # Convert to Cartesian offsets

--- a/xmm_simulator/point_sources.py
+++ b/xmm_simulator/point_sources.py
@@ -52,7 +52,8 @@ def gen_sources(xmmsim, outfile=None, outreg=None):
 
     n_src = np.random.poisson(N_gt15 * field_area)
 
-    npix = xmmsim.box.shape[0]
+    #npix = xmmsim.box.shape[0]
+    npix = xmmsim.boxshape0
 
     S_grid_15 = np.logspace(-15, -12, 1000)  # cutting at -12 as greater values are highly improbable in a 0.25 square deg area
 
@@ -130,7 +131,8 @@ def pts_box(xmmsim, source_file):
 
     norm = Fx_pts / flux_norm_conv
 
-    box_pts = np.zeros(xmmsim.box.shape)
+    #box_pts = np.zeros(xmmsim.box.shape)
+    box_pts = np.zeros((xmmsim.boxshape0, xmmsim.boxshape1, xmmsim.boxshape2))
 
     npts = len(X_pts)
 
@@ -146,8 +148,10 @@ def pts_box(xmmsim, source_file):
         iX = int(X_pts[i] + 0.5)
         iY = int(Y_pts[i] + 0.5)
 
-        if iX==xmmsim.box.shape[1]: iX = xmmsim.box.shape[1] - 1
-        if iY==xmmsim.box.shape[0]: iY = xmmsim.box.shape[0] - 1
+        #if iX==xmmsim.box.shape[1]: iX = xmmsim.box.shape[1] - 1
+        #if iY==xmmsim.box.shape[0]: iY = xmmsim.box.shape[0] - 1
+        if iX==xmmsim.boxshape1: iX = xmmsim.boxshape1 - 1
+        if iY==xmmsim.boxshape0: iY = xmmsim.boxshape0 - 1
 
         box_pts[iY, iX, :] = mod(xmmsim.box_ene_mean) * xmmsim.tsim * xmmsim.all_arfs[iY, iX, :]
 

--- a/xmm_simulator/simulator.py
+++ b/xmm_simulator/simulator.py
@@ -596,7 +596,7 @@ class XMMSimulator(object):
         :param NH: Absorption column density
         :type NH: float
         """
-        if self.box:
+        if self.box is not None:
             print('# Compute model box...')
             phot_box_ima = gen_phot_box(self,
                                         tsim=self.tsim,

--- a/xmm_simulator/simulator.py
+++ b/xmm_simulator/simulator.py
@@ -6,7 +6,7 @@ from .background import gen_qpb_image, gen_skybkg_image, gen_skybkg_spectrum, ge
 from .utils import get_ccf_file_names, calc_arf, get_data_file_path
 from .imaging import gen_image_box, save_maps, exposure_map
 from .spectral import gen_spec_box, save_spectrum, gen_spec_evt, gen_spec_evt_pix
-from .event_file import gen_phot_box, gen_evt_list, gen_qpb_evt, merge_evt, save_evt_file, gen_image_evt, load_events
+from .event_file import gen_phot_box, gen_evt_list, gen_qpb_evt, merge_evt, save_evt_file, gen_image_evt, load_events, gen_phot_evtlist
 from .point_sources import gen_sources, pts_box
 from scipy.interpolate import interp1d
 
@@ -14,8 +14,8 @@ class XMMSimulator(object):
     """
 
     """
-    def __init__(self, boxfile, ccfpath, instrument, tsim,
-                 box_size=0.5, box_ene=None, abund='angr'):
+    def __init__(self, ccfpath, instrument, tsim, boxfile=None,
+                 evtfile_input=None, box_size=0.5, box_ene=None, abund='angr'):
         """
         Constructor of class XMMSimulator
 
@@ -27,6 +27,8 @@ class XMMSimulator(object):
         :type instrument: str
         :param tsim: Simulation exposure time
         :type tsim: float
+        :param evtfile_input: Input event file (in the format of output event file from pyxsim)
+        :type evtfile_input: str
         :param box_size: Size of the provided simulation box in degrees (defaults to 0.5)
         :type box_size: float
         :param box_ene: Numpy array containing the energy definition of the box. If None, defaults to a linear grid between 0.1 and 10 keV with a step of 0.02
@@ -43,20 +45,49 @@ class XMMSimulator(object):
             print('ERROR: instrument should be one of PN, MOS1, or MOS2')
             return
 
-        fb = fits.open(boxfile)
+        try:
+            if boxfile is None and evtfile_input is None:
+                raise ValueError
+        except ValueError:
+            print('ERROR: you need to provide at least a path to a boxfile or a path to an input eventfile')
 
-        self.box = fb[0].data
+        try:
+            if boxfile is not None and evtfile_input is not None:
+                raise ValueError
+        except ValueError:
+            print('ERROR: you provided a path to a boxfile and a path to an input eventfile. Choose one of the two')
 
-        self.box_size = box_size * 60. # arcmin
 
-        fb.close()
+        self.box_size = box_size * 60.  # arcmin
+        if boxfile:
+            fb = fits.open(boxfile)
+
+            self.box = fb[0].data
+
+            self.pixsize = self.box_size / self.box.shape[0]
+
+            self.boxshape0 = self.box.shape[0]
+            self.boxshape1 = self.box.shape[1]
+            self.boxshape2 = self.box.shape[2]
+
+            fb.close()
+            self.evtfile_input = None
+        else:
+            self.box = None
+            self.evtfile_input = evtfile_input
+            self.boxshape0 = 100#512
+            self.boxshape1 = 100#512
+            self.boxshape2 = 99#495
+            self.pixsize = self.box_size / self.boxshape0
+
 
         if box_ene is None:
-            self.box_ene = np.arange(0.1, 10.01, 0.02)
-
-            self.box_ene_mean = np.arange(0.11, 10., 0.02)
-
-            self.box_ene_width = 0.02
+            #self.box_ene = np.arange(0.1, 10.01, 0.02)
+            #self.box_ene_mean = np.arange(0.11, 10., 0.02)
+            #self.box_ene_width = 0.02
+            self.box_ene = np.linspace(0.1, 10.01, self.boxshape2+1)
+            self.box_ene_mean = np.linspace(0.11, 10., self.boxshape2)
+            self.box_ene_width = np.diff(self.box_ene_mean)[0]
         else:
             self.box_ene = box_ene
 
@@ -135,12 +166,14 @@ class XMMSimulator(object):
         Compute the ARFs for each point on the box
 
         """
+        #redefined by rseppi as self.pixsize
+        #pixsize = self.box_size / self.box.shape[0]  # by default box size is 30 arcmin
 
-        pixsize = self.box_size / self.box.shape[0]  # by default box size is 30 arcmin
+        #y, x = np.indices(self.box[:, :, 0].shape)
+        y, x = np.indices((self.boxshape0, self.boxshape1))
 
-        y, x = np.indices(self.box[:, :, 0].shape)
-
-        cx, cy = self.box.shape[0] / 2., self.box.shape[1] / 2.
+        #cx, cy = self.box.shape[0] / 2., self.box.shape[1] / 2.
+        cx, cy = self.boxshape0 / 2., self.boxshape1 / 2.
 
         self.cx = cx
         self.cy = cy
@@ -149,9 +182,10 @@ class XMMSimulator(object):
 
         thetas = np.linspace(0., 22., nthetas)
 
-        theta_image = np.hypot(x - cx, y - cy) * pixsize  # arcmin
+        theta_image = np.hypot(x - cx, y - cy) * self.pixsize  # arcmin
 
-        nene_ori = self.box.shape[2]
+        #nene_ori = self.box.shape[2]
+        nene_ori = self.boxshape2
 
         ene_lo, ene_hi = self.box_ene[:nene_ori], self.box_ene[1:]
 
@@ -562,21 +596,36 @@ class XMMSimulator(object):
         :param NH: Absorption column density
         :type NH: float
         """
+        if self.box:
+            print('# Compute model box...')
+            phot_box_ima = gen_phot_box(self,
+                                        tsim=self.tsim,
+                                        with_skybkg=withskybkg,
+                                        lhb=lhb,
+                                        ght=ght,
+                                        ghn=ghn,
+                                        cxb=cxb,
+                                        NH=NH,
+                                        abund=self.abund)
 
-        print('# Compute model box...')
-        phot_box_ima = gen_phot_box(self,
-                                    tsim=self.tsim,
-                                    with_skybkg=withskybkg,
-                                    lhb=lhb,
-                                    ght=ght,
-                                    ghn=ghn,
-                                    cxb=cxb,
-                                    NH=NH,
-                                    abund=self.abund)
+            print('# Generate sky events...')
+            X_evt, Y_evt, chan_evt = gen_evt_list(self,
+                                                  phot_box_ima=phot_box_ima)
 
-        print('# Generate sky events...')
-        X_evt, Y_evt, chan_evt = gen_evt_list(self,
-                                              phot_box_ima=phot_box_ima)
+        elif self.evtfile_input:
+            X_evt, Y_evt, chan_evt = gen_phot_evtlist(self,
+                                                      tsim=self.tsim,
+                                                      with_skybkg=withskybkg,
+                                                      lhb=lhb,
+                                                      ght=ght,
+                                                      ghn=ghn,
+                                                      cxb=cxb,
+                                                      NH=NH,
+                                                      abund=self.abund)
+
+        else:
+            print('You need to provide either a box or an ideal event file.')
+            return
 
         if self.fwc_spec is None:
             print('FWC events not extracted yet, skipping QPB event generation')

--- a/xmm_simulator/simulator.py
+++ b/xmm_simulator/simulator.py
@@ -64,7 +64,7 @@ class XMMSimulator(object):
 
             self.box = fb[0].data
 
-            self.pixsize = self.box_size / self.box.shape[0]
+            self.pixsize_ori = self.box_size / self.box.shape[0]
 
             self.boxshape0 = self.box.shape[0]
             self.boxshape1 = self.box.shape[1]
@@ -75,10 +75,10 @@ class XMMSimulator(object):
         else:
             self.box = None
             self.evtfile_input = evtfile_input
-            self.boxshape0 = 100#512
-            self.boxshape1 = 100#512
-            self.boxshape2 = 99#495
-            self.pixsize = self.box_size / self.boxshape0
+            self.boxshape0 = 512#512
+            self.boxshape1 = 512#512
+            self.boxshape2 = 495#495
+            self.pixsize_ori = self.box_size / self.boxshape0
 
 
         if box_ene is None:
@@ -166,7 +166,7 @@ class XMMSimulator(object):
         Compute the ARFs for each point on the box
 
         """
-        #redefined by rseppi as self.pixsize
+        #redefined by rseppi as self.pixsize_ori
         #pixsize = self.box_size / self.box.shape[0]  # by default box size is 30 arcmin
 
         #y, x = np.indices(self.box[:, :, 0].shape)
@@ -182,7 +182,7 @@ class XMMSimulator(object):
 
         thetas = np.linspace(0., 22., nthetas)
 
-        theta_image = np.hypot(x - cx, y - cy) * self.pixsize  # arcmin
+        theta_image = np.hypot(x - cx, y - cy) * self.pixsize_ori  # arcmin
 
         #nene_ori = self.box.shape[2]
         nene_ori = self.boxshape2

--- a/xmm_simulator/utils.py
+++ b/xmm_simulator/utils.py
@@ -240,29 +240,29 @@ def set_wcs(xmmsim, type='mask'):
 
     inmask.close()
 
-    ima = xmmsim.box[:, :, 0]
-
-    hdu = fits.PrimaryHDU(ima)
-
     npix_mask = mask.shape[0]
 
-    npix_box = ima.shape[0]
+    #npix_box = ima.shape[0]
+    npix_box = xmmsim.boxshape0
 
     if type == 'box':
-        header = hdu.header
+        pixsize_ori = xmmsim.box_size / 60. / xmmsim.boxshape1  # degree
 
-        pixsize_ori = xmmsim.box_size / 60. / xmmsim.box.shape[1] # degree
+        if xmmsim.box:
+            ima = xmmsim.box[:, :, 0]
+            hdu = fits.PrimaryHDU(ima)
+            header = hdu.header
+        else:
+            header = fits.Header()
 
         header['CDELT1'] = - pixsize_ori
         header['CDELT2'] = pixsize_ori
         header['CRPIX1'] = head_mask['CRPIX1'] * npix_box / npix_mask
         header['CRPIX2'] = head_mask['CRPIX2'] * npix_box / npix_mask
-
         header['CTYPE1'] = head_mask['CTYPE1']
         header['CTYPE2'] = head_mask['CTYPE2']
         header['CRVAL1'] = 0.
         header['CRVAL2'] = 0.
-
         wcs = WCS(header)
 
     else:

--- a/xmm_simulator/utils.py
+++ b/xmm_simulator/utils.py
@@ -248,7 +248,7 @@ def set_wcs(xmmsim, type='mask'):
     if type == 'box':
         pixsize_ori = xmmsim.box_size / 60. / xmmsim.boxshape1  # degree
 
-        if xmmsim.box:
+        if xmmsim.box is not None:
             ima = xmmsim.box[:, :, 0]
             hdu = fits.PrimaryHDU(ima)
             header = hdu.header


### PR DESCRIPTION
I added the possibility to use idealized photon lists (generated for example with pyxsim) as input to XMMSimulator. Now the XMMSimulator class accepts two inputs, i.e. boxfile and eventfile_input, and based on what the user provides, it will either generate photons from the 3D data cube or downgrade the idealized event list based on the ratio between the idealized and the desired exposure time and the XMM-Newton response across the field of view.